### PR TITLE
Fix the npm install command in the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ composer require nativephp/php-bin --dev
 or NPM:
 
 ```shell
-npm -i @nativephp/php-bin --save-dev
+npm i @nativephp/php-bin --save-dev
 ```
 
 ### ℹ️ Heads up...


### PR DESCRIPTION
# Context
Most people will probably copy/paste the commands due to the typo in the npm install command it fails and causes confusion, hopefully this small change will help avoid the confusion. 