### PR TITLE
Fix PHP 8.4 builds on Windows

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -39,28 +39,6 @@ jobs:
           [ ! -d php-bin ] && mkdir -p php-bin
           cd php-bin
 
-      # Copy downloads/micro/patches/cli_static.patch
-      # to downloads/micro/patches/cli_static_80.patch
-      # to downloads/micro/patches/cli_static_81.patch
-      # to downloads/micro/patches/cli_static_82.patch
-      # to downloads/micro/patches/cli_static_83.patch
-      # to downloads/micro/patches/cli_static_84.patch
-      #
-      # Remove downloads/micro/patches/cli_static.patch
-      # Remove line 18 of downloads/micro/patches/cli_static_84.patch
-      - name: Fix micro patches
-        shell: bash
-        run: |
-          cd ../static-php-cli
-          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_80.patch
-          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_81.patch
-            cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_82.patch
-            cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_83.patch
-            cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_84.patch
-            sed -i '' '18d' downloads/micro/patches/cli_static_84.patch
-            rm -f downloads/micro/patches/cli_static.patch
-          cd ../php-bin
-
       - shell: bash
         run: |
           PHP_VERSION=$(echo "${{ matrix.version }}" | cut -d. -f1,2)

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -120,23 +120,20 @@ jobs:
           ./bin/spc download --with-php=${{ matrix.version }} --for-extensions "${{ env.PHP_EXTENSIONS }}" --prefer-pre-built
           cd ../php-bin
 
-
       - name: Patch for windows 8.4 builds
         shell: bash
         run: |
-           cd ../static-php-cli
-           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_80.patch
-           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_81.patch
-           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_82.patch
-           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_83.patch
-           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_84.patch
-#          Remove line 18 of downloads/micro/patches/cli_static_84.patch
-           sed -i '18d' downloads/micro/patches/cli_static_84.patch
-#          Change line 14 of downloads/micro/patches/cli_static_84.patch
-           sed -i 's/+1160,11/+1160,10/' downloads/micro/patches/cli_static_84.patch
-           rm -f downloads/micro/patches/cli_static.patch
-           cat downloads/micro/patches/cli_static_84.patch
-           cd ../php-bin
+          cd ../static-php-cli
+          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_80.patch
+          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_81.patch
+          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_82.patch
+          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_83.patch
+          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_84.patch
+          sed -i '18d' downloads/micro/patches/cli_static_84.patch
+          sed -i 's/+1160,11/+1160,10/' downloads/micro/patches/cli_static_84.patch
+          rm -f downloads/micro/patches/cli_static.patch
+          cat downloads/micro/patches/cli_static_84.patch
+          cd ../php-bin
 
       - name: Build PHP
         run: |

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -39,6 +39,28 @@ jobs:
           [ ! -d php-bin ] && mkdir -p php-bin
           cd php-bin
 
+      # Copy downloads/micro/patches/cli_static.patch
+      # to downloads/micro/patches/cli_static_80.patch
+      # to downloads/micro/patches/cli_static_81.patch
+      # to downloads/micro/patches/cli_static_82.patch
+      # to downloads/micro/patches/cli_static_83.patch
+      # to downloads/micro/patches/cli_static_84.patch
+      #
+      # Remove downloads/micro/patches/cli_static.patch
+      # Remove line 18 of downloads/micro/patches/cli_static_84.patch
+      - name: Fix micro patches
+        shell: bash
+        run: |
+          cd ../static-php-cli
+          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_80.patch
+          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_81.patch
+            cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_82.patch
+            cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_83.patch
+            cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_84.patch
+            sed -i '' '18d' downloads/micro/patches/cli_static_84.patch
+            rm -f downloads/micro/patches/cli_static.patch
+          cd ../php-bin
+
       - shell: bash
         run: |
           PHP_VERSION=$(echo "${{ matrix.version }}" | cut -d. -f1,2)

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -35,7 +35,9 @@ jobs:
           git clone https://github.com/crazywhalecc/static-php-cli.git
           cd static-php-cli
           git checkout main
-          cd ../php-bin
+          cd ../
+          [ ! -d php-bin ] && mkdir -p php-bin
+          cd php-bin
 
       - shell: bash
         run: |

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -120,6 +120,24 @@ jobs:
           ./bin/spc download --with-php=${{ matrix.version }} --for-extensions "${{ env.PHP_EXTENSIONS }}" --prefer-pre-built
           cd ../php-bin
 
+
+      - name: Patch for windows 8.4 builds
+        shell: bash
+        run: |
+           cd ../static-php-cli
+           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_80.patch
+           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_81.patch
+           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_82.patch
+           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_83.patch
+           cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_84.patch
+#          Remove line 18 of downloads/micro/patches/cli_static_84.patch
+           sed -i '18d' downloads/micro/patches/cli_static_84.patch
+#          Change line 14 of downloads/micro/patches/cli_static_84.patch
+           sed -i 's/+1160,11/+1160,10/' downloads/micro/patches/cli_static_84.patch
+           rm -f downloads/micro/patches/cli_static.patch
+           cat downloads/micro/patches/cli_static_84.patch
+           cd ../php-bin
+
       - name: Build PHP
         run: |
           cd ../static-php-cli

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -119,7 +119,6 @@ jobs:
           cd ../php-bin
 
       - name: Build PHP
-        shell: bash
         run: |
           cd ../static-php-cli
           ./bin/spc build --build-cli "${{ env.PHP_EXTENSIONS }}"

--- a/php-extensions.txt
+++ b/php-extensions.txt
@@ -1,1 +1,1 @@
-bcmath,ctype,curl,dom,fileinfo,filter,gd,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib
+bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib


### PR DESCRIPTION
Fix the following:

-  Fix: "7za | tar" pipe not working on the bash shell
-  Fix: php-bin directory not existing when you fork the project without a previous build cache
-  Fix: used the [cli generator](https://static-php.dev/en/guide/cli-generator.html) to update essential dependencies


Unfortunately, this does not resolve the PHP 8.4 Windows build issue, but it does fix and improve the current build action.

The last remaining error is related to the following patch that @mpociot commented on: https://github.com/static-php/phpmicro/pull/3#issuecomment-2500051141

If you're curious about my research that led to those commits, see https://github.com/SRWieZ/fork-nativephp-php-bin/pull/1.