### PR TITLE
revert windows patch

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -120,22 +120,6 @@ jobs:
           ./bin/spc download --with-php=${{ matrix.version }} --for-extensions "${{ env.PHP_EXTENSIONS }}" --prefer-pre-built
           cd ../php-bin
 
-      - name: Patch for windows 8.4 builds
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          cd ../static-php-cli
-          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_80.patch
-          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_81.patch
-          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_82.patch
-          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_83.patch
-          cp downloads/micro/patches/cli_static.patch downloads/micro/patches/cli_static_84.patch
-          sed -i '18d' downloads/micro/patches/cli_static_84.patch
-          sed -i 's/+1160,11/+1160,10/' downloads/micro/patches/cli_static_84.patch
-          rm -f downloads/micro/patches/cli_static.patch
-          cat downloads/micro/patches/cli_static_84.patch
-          cd ../php-bin
-
       - name: Build PHP
         run: |
           cd ../static-php-cli


### PR DESCRIPTION
- Merged into  branch : https://github.com/static-php/phpmicro/pull/5
- Along with other fixes to upstream: https://github.com/easysoft/phpmicro/pull/20

Should already work since static-php-cli uses patches from [static-php:84beta](https://github.com/static-php/phpmicro/tree/84beta) ([source](https://github.com/crazywhalecc/static-php-cli/blob/main/config/source.json#L601))
