### PR TITLE
Naming conventions across build targets

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -52,10 +52,6 @@ jobs:
         run: echo "SPC_BUILD_ARCH=arm64" >> $GITHUB_ENV
 
       - shell: bash
-        if: matrix.os == 'macos-13'
-        run: echo "SPC_BUILD_ARCH=x86" >> $GITHUB_ENV
-
-      - shell: bash
         if: contains(matrix.os, 'macos')
         run: |
           brew install automake gzip


### PR DESCRIPTION
This change normalises naming conventions across build targets.

Goes along with commit https://github.com/NativePHP/electron/pull/153/commits/b0b9c349a07ff0e4c0f3a7b7df0d34a91f4b7935 in PR https://github.com/NativePHP/electron/pull/153