### PR TITLE
bring back `windows-latest` in os matrix

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         version: ["8.1", "8.2", "8.3", "8.4"]
-        os: [ "macos-13", "macos-latest", "ubuntu-latest", "ubuntu-24.04-arm" ]
+        os: [ "macos-13", "macos-latest", "windows-latest", "ubuntu-latest", "ubuntu-24.04-arm" ]
 
     continue-on-error: true
 


### PR DESCRIPTION
This was removed accidentally in a previous PR