### PR TITLE
fix: linux arm64 bin directory

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -136,6 +136,13 @@ jobs:
           fi
           echo "PHP_VERSION_FULL=$PHP_VERSION_FULL" >> $GITHUB_ENV
 
+      - name: Create bin directories
+        shell: bash
+        run: |
+          mkdir -p bin/${{ env.SPC_BUILD_OS }}/${{ env.SPC_BUILD_ARCH }}
+          mkdir -p license-files
+          mkdir -p build-meta
+
       - name: Zip PHP binary, copy metadata
         shell: bash
         run: |


### PR DESCRIPTION
Linux arm64 fails because `bin/linux/arm64` does not exists. 

This is the fix for it.