### PR TITLE
Pin to v2.4.4 with easy updates in future

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
+  SPC_VERSION: 2.5.0
 
 jobs:
   build:
@@ -35,28 +36,28 @@ jobs:
       - name: Set SPC URL for macos-13
         shell: bash
         if: matrix.os == 'macos-13'
-        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-macos-x86_64.tar.gz" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-macos-x86_64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for macos-latest
         shell: bash
         if: matrix.os == 'macos-latest'
-        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-macos-aarch64.tar.gz" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-macos-aarch64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for ubuntu-latest and ubuntu-24.04
         shell: bash
         if: matrix.os == 'ubuntu-latest'
-        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-linux-x86_64.tar.gz" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-linux-x86_64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for ubuntu-24.04-arm
         shell: bash
         if: matrix.os == 'ubuntu-24.04-arm'
-        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-linux-aarch64.tar.gz" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-linux-aarch64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for windows-latest
         shell: bash
         if: matrix.os == 'windows-latest'
         run: | 
-          echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-windows-x64.exe" >> $GITHUB_ENV
+          echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/${{ env.SPC_VERSION }}/spc-windows-x64.exe" >> $GITHUB_ENV
           echo "SPC_BINARY=spc.exe" >> $GITHUB_ENV
 
       - name: Download SPC

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -13,6 +13,9 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
   SPC_VERSION: 2.4.4
+  # Temporary workaround. See https://github.com/NativePHP/laravel/issues/522#issuecomment-2736250539
+  # Remove when updating SPC version
+  WINBUILD_ACKNOWLEDGE_DEPRECATED: yes
 
 jobs:
   build:

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Build PHP
         run: |
           cd ../static-php-cli
-          ./bin/${{ env.SPC_BINARY }} build --build-cli "${{ env.PHP_EXTENSIONS }}" --with-libs="${{ env.PHP_LIBS }}"
+          ./bin/${{ env.SPC_BINARY }} build --build-cli "${{ env.PHP_EXTENSIONS }}" --with-libs="${{ env.PHP_LIBS }}" --debug
           cd ../php-bin
 
       - name: Get built PHP version

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
-  SPC_VERSION: 2.5.0
+  SPC_VERSION: 2.4.5
 
 jobs:
   build:

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
-  SPC_VERSION: 2.4.5
+  SPC_VERSION: 2.4.4
 
 jobs:
   build:

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -35,35 +35,40 @@ jobs:
       - name: Set SPC URL for macos-13
         shell: bash
         if: matrix.os == 'macos-13'
-        run: echo "SPC_URL=https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-macos-x86_64" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-macos-x86_64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for macos-latest
         shell: bash
         if: matrix.os == 'macos-latest'
-        run: echo "SPC_URL=https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-macos-aarch64" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-macos-aarch64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for ubuntu-latest and ubuntu-24.04
         shell: bash
         if: matrix.os == 'ubuntu-latest'
-        run: echo "SPC_URL=https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-x86_64" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-linux-x86_64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for ubuntu-24.04-arm
         shell: bash
         if: matrix.os == 'ubuntu-24.04-arm'
-        run: echo "SPC_URL=https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-aarch64" >> $GITHUB_ENV
+        run: echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-linux-aarch64.tar.gz" >> $GITHUB_ENV
 
       - name: Set SPC URL for windows-latest
         shell: bash
         if: matrix.os == 'windows-latest'
         run: | 
-          echo "SPC_URL=https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-windows-x64.exe" >> $GITHUB_ENV
+          echo "SPC_URL=https://github.com/crazywhalecc/static-php-cli/releases/download/2.5.0/spc-windows-x64.exe" >> $GITHUB_ENV
           echo "SPC_BINARY=spc.exe" >> $GITHUB_ENV
 
       - name: Download SPC
         shell: bash
         run: |
           cd ..
-          curl -fsSL -o ${{ env.SPC_BINARY }} ${{ env.SPC_URL }}
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            curl -fsSL -o ${{ env.SPC_BINARY }} ${{ env.SPC_URL }}
+          else
+            curl -fsSL -o ${{ env.SPC_BINARY }}.tar.gz ${{ env.SPC_URL }}
+            tar -xzf ${{ env.SPC_BINARY }}.tar.gz
+          fi
           chmod +x ${{ env.SPC_BINARY }}
           [ ! -d static-php-cli/bin ] && mkdir -p static-php-cli/bin
           mv ${{ env.SPC_BINARY }} static-php-cli/bin/


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build-php.yml` file to address issues with the SPC version and improve the build process. The most important changes include setting a specific SPC version, updating SPC URLs for different operating systems, and adding a debug flag to the build command.

Environment variable updates:

* Added `SPC_VERSION` and `WINBUILD_ACKNOWLEDGE_DEPRECATED` environment variables to address a temporary workaround for an issue with SPC versioning.

SPC URL updates:

* Updated SPC URLs for `macos-13`, `macos-latest`, `ubuntu-latest`, `ubuntu-24.04-arm`, and `windows-latest` to use the new SPC version-specific URLs from GitHub releases.

Build process improvement:

* Modified the download and extraction process for SPC binaries to handle different file formats based on the operating system.
* Added the `--debug` flag to the PHP build command to enable debug mode during the build process.

Fixes https://github.com/NativePHP/laravel/issues/522