### PR TITLE
Drop PHP 8.1 and 8.2 support from workflows

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        version: ["8.1", "8.2", "8.3", "8.4"]
+        version: ["8.3", "8.4"]
         os: [ "macos-13", "macos-latest", "windows-latest", "ubuntu-latest", "ubuntu-24.04-arm" ]
 
     continue-on-error: true
@@ -113,7 +113,7 @@ jobs:
       - name: Setup system PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           tools: pecl, composer
           extensions: curl, openssl, mbstring, sodium, tokenizer
           ini-values: memory_limit=-1


### PR DESCRIPTION
This pull request includes updates to the PHP version matrix in the GitHub Actions workflow configuration file `.github/workflows/build-php.yml`. The most important changes are:

* Updated the PHP version matrix to remove versions 8.1 and 8.2, keeping only versions 8.3 and 8.4. (`.github/workflows/build-php.yml`, [.github/workflows/build-php.ymlL27-R27](diffhunk://#diff-e86edc20f1ed60d2f26df18716af1bfabda3ee4226a724e46d77161df5a5c551L27-R27))
* Changed the system PHP setup to use version 8.3 instead of 8.2. (`.github/workflows/build-php.yml`, [.github/workflows/build-php.ymlL116-R116](diffhunk://#diff-e86edc20f1ed60d2f26df18716af1bfabda3ee4226a724e46d77161df5a5c551L116-R116))