### PR TITLE
Update php-extensions.txt

### DIFF
--- a/php-extensions.txt
+++ b/php-extensions.txt
@@ -1,1 +1,1 @@
-bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib
+bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib,xmlreader


### PR DESCRIPTION
This pull request proposes the inclusion of the xmlreader extension in the php-extensions.txt list for the NativePHP php-bin project. xmlreader is a lightweight, forward-only XML parser that provides an efficient way to read and process large XML documents with low memory overhead. This extension is commonly required by libraries and frameworks that rely on streaming XML data.

This change helps improve out-of-the-box support for projects using NativePHP that rely on xmlreader.