### PR TITLE
chore: update SPC_VERSION to 2.6.1 and add intl extension

### DIFF
--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
-  SPC_VERSION: 2.5.2
+  SPC_VERSION: 2.6.1
 
 jobs:
   build:

--- a/php-extensions.txt
+++ b/php-extensions.txt
@@ -1,1 +1,1 @@
-bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib
+bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,intl,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib


### PR DESCRIPTION
* Upgrading `SPC_VERSION` from `2.5.2` to `2.6.1` in `.github/workflows/build-php.yml`
* Adding `intl` extension to `php-extensions.txt` for internationalization support