### PR TITLE
add mbregex extension

### DIFF
--- a/php-extensions.txt
+++ b/php-extensions.txt
@@ -1,1 +1,1 @@
-bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,intl,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib
+bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,intl,mbstring,mbregex,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,zip,zlib


### PR DESCRIPTION
This PR adds the `mbregex` PHP extension to the list of enabled extensions.

Fixes https://github.com/NativePHP/laravel/issues/662