### PR TITLE
Add xmlwriter and xmlreader extensions

### DIFF
--- a/php-extensions.txt
+++ b/php-extensions.txt
@@ -1,1 +1,1 @@
-bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,intl,mbstring,mbregex,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sodium,sqlite3,tokenizer,xml,zip,zlib
+bcmath,bz2,ctype,curl,dom,fileinfo,filter,gd,iconv,intl,mbstring,mbregex,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sodium,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib


### PR DESCRIPTION
PhpSpreadsheet (a common library for reading/writing Excel files) requires
ext-xmlwriter unconditionally to write any .xlsx file — it's instantiated
directly throughout its writer code with no fallback. It's currently missing
from the default extension list, so any NativePHP app that writes Excel files
hits a fatal `Class "XMLWriter" not found` error when saving.

Adding xmlreader too, since PhpSpreadsheet lists it as a hard composer.json
requirement as well, even though my own use case only hit the xmlwriter gap.

Confirmed both are supported on Windows/Linux/macOS per static-php-cli's own
extension support table: https://static-php.dev/en/guide/extensions.html